### PR TITLE
Tiny update when player exit a vehicle

### DIFF
--- a/scripts/SSS/Vehicle/Spawn.pwn
+++ b/scripts/SSS/Vehicle/Spawn.pwn
@@ -636,12 +636,18 @@ public OnVehicleSpawn(vehicleid)
 	}
 }
 
+hook OnPlayerExitVehicle(playerid, vehicleid)
+{
+	new modelid = GetVehicleModel(vehicleid);
+	if(modelid == 449 || modelid == 537 || modelid == 538 || modelid == 569 || modelid == 570 || modelid == 590) {
+		SetCameraBehindPlayer(playerid);
+	}
+}
 
 hook OnPlayerStateChange(playerid, newstate, oldstate)
 {
 	if(oldstate == PLAYER_STATE_DRIVER)
 	{
-		SetCameraBehindPlayer(playerid);
 		SavePlayerVehicle(gPlayerVehicleID[playerid], gPlayerName[playerid], true);
 	}
 }


### PR DESCRIPTION
Need to set the camera behind the player only when is exit from trains (vid: 449, 537, 538, 569, 570, 590) ...
Not every time when exit from an vehicle (is a bit annoying this this kind of method)
