### PR TITLE
Ability to add names to exceptions list, when exeptioncount == 0

### DIFF
--- a/gamemodes/sss/core/admin/detfield-cmds.pwn
+++ b/gamemodes/sss/core/admin/detfield-cmds.pwn
@@ -326,7 +326,10 @@ ShowDetfieldListOptions(playerid, detfieldid)
 
 				case 2:
 				{
-					ShowDetfieldExceptions(playerid, detfieldid);
+					if(exceptioncount > 0)
+						ShowDetfieldExceptions(playerid, detfieldid);
+					else
+						ShowDetfieldAddException(playerid, detfieldid, -1);
 				}
 
 				case 3:
@@ -489,7 +492,10 @@ ShowDetfieldAddException(playerid, detfieldid, exceptionid)
 		}
 		else
 		{
-			ShowDetfieldExceptionOptions(playerid, detfieldid, exceptionid);
+			if(exceptionid != -1)
+				ShowDetfieldExceptionOptions(playerid, detfieldid, exceptionid);
+			else
+				ShowDetfieldListOptions(playerid, detfieldid);
 		}
 	}
 	Dialog_ShowCallback(playerid, using inline Response, DIALOG_STYLE_INPUT, sprintf("Add exception for %s", name), "Type a username:", "Add", "Back");


### PR DESCRIPTION
It was annoying, when someone deleted all exception names from the
detection fields, and you had to delete the whole det field to add
exceptions again. This fixes that issue.