### PR TITLE
Buf Fix; Update (tm<var>) to (var[e_tm])

### DIFF
--- a/gamemodes/sss/utils/time.pwn
+++ b/gamemodes/sss/utils/time.pwn
@@ -40,7 +40,7 @@ stock TimestampToDateTime(datetime, format[] = CTIME_DATE_TIME)
 {
 	new
 		str[64],
-		tm<timestamp>;
+		timestamp[e_tm];
 
 	localtime(Time:datetime, timestamp);
 	strftime(str, 64, format, timestamp);


### PR DESCRIPTION
Change the old mode to declare `tm<var>` to new mode `var[e_tm]`.
See the [pawn-ctime](https://github.com/Southclaws/pawn-ctime) Readme: ([link](https://imgur.com/sQn5nn9))