### PR TITLE
Fixing the infinite ammo bug when shooting defenses

### DIFF
--- a/gamemodes/sss/core/itemtype/defences.pwn
+++ b/gamemodes/sss/core/itemtype/defences.pwn
@@ -81,6 +81,10 @@ forward OnPlayerInteractDefence(playerid, Item:itemid);
 
 ==============================================================================*/
 
+public OnPlayerShootDynamicObject(playerid, weaponid, STREAMER_TAG_OBJECT:objectid, Float:x, Float:y, Float:z)
+{
+	return 1;
+}
 
 hook OnPlayerConnect(playerid)
 {


### PR DESCRIPTION
Fixing the infinite ammo bug when shooting defenses (and other objects)