### PR TITLE
avoid compiler error

### DIFF
--- a/legacy/item-serializer.inc
+++ b/legacy/item-serializer.inc
@@ -10,7 +10,6 @@
 #define _item_serializer_included
 
 #include <a_samp>
-#include <uuid>
 #include <item>
 
 #include <YSI_Coding\y_hooks>


### PR DESCRIPTION
uuid 1.0.1 doesn't have include guard so it may cause an error